### PR TITLE
When predefined id is setted, It doesn't spect content from store reques...

### DIFF
--- a/Client/Api/StatementsApiClient.php
+++ b/Client/Api/StatementsApiClient.php
@@ -146,7 +146,10 @@ class StatementsApiClient extends ApiClient implements StatementsApiClientInterf
             return $createdStatements;
         } else {
             $createdStatement = clone $statements;
-            $createdStatement->setId($statementIds[0]);
+
+            if (200 === $validStatusCode) {
+                $createdStatement->setId($statementIds[0]);
+            }
 
             return $createdStatement;
         }


### PR DESCRIPTION
...t (following xAPI spec 204 is used when id is included), so in case of 204 we don't need to fill id 

Fixed #1
